### PR TITLE
perf/general

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,13 @@ import type { NAMED_COLORS_ARRAY } from "./constants";
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type AnyObject = Record<PropertyKey, any>;
 
+export type ObjectKey<TObj extends AnyObject> = keyof TObj;
+export type ObjectValue<TObj extends AnyObject> = TObj[ObjectKey<TObj>];
+export type ObjectEntry<TObj extends AnyObject> = [
+  ObjectKey<TObj>,
+  ObjectValue<TObj>,
+];
+
 /**
  * A utility type that represents a string or a string with a `-foreground` suffix.
  *


### PR DESCRIPTION
fix: :zap: improve mapObject utility performance and general refactor

- :bulb: Replaced `reduce` with a `for` loop in `mapObject` for better performance (closes #1)
- :recycle: Refactored `mapObject` and `mapThemeColors` for clarity
- :art: Improved function documentation and type definitions
- :sparkles: Introduced new helper functions `mapThemeColors` and `mapThemeBase` to simplify `shadcnTwPlugin` implementation

Enhanced performance and maintainability by optimizing the `mapObject` utility and refactoring related functions.